### PR TITLE
Fixes Get-SecurityGroups

### DIFF
--- a/GraphRunner.ps1
+++ b/GraphRunner.ps1
@@ -2405,7 +2405,7 @@ function Get-SecurityGroups{
     }
     
     $graphApiUrl = "https://graph.microsoft.com/v1.0"
-    $groupsUrl = "$graphApiUrl/groups?$filter=securityEnabled eq true"
+    $groupsUrl = "$graphApiUrl/groups?`$filter=securityEnabled eq true"
     
     $groupsWithMemberIDs = @()
     $startTime = Get-Date


### PR DESCRIPTION
The code previously returned all groups, not just security groups.

This PR fixes #22