### PR TITLE
URL-encoded email address in guest invite 

### DIFF
--- a/GraphRunner.ps1
+++ b/GraphRunner.ps1
@@ -4806,7 +4806,7 @@ function Invoke-InviteGuest{
 
     # Construct the JSON payload
     $invitationData = @{
-        invitedUserEmailAddress = $EmailAddress
+        invitedUserEmailAddress = [System.Web.HttpUtility]::UrlEncode($EmailAddress)
         invitedUserDisplayname = $Displayname
         inviteRedirectUrl = $RedirectUrl
         sendInvitationMessage = [System.Convert]::ToBoolean($SendInvitationMessage)


### PR DESCRIPTION
PrincipalName is commonly used in dynamic membership rules and is typically derived from the email address. In some cases, including a # in the local part of the email address may be necessary to influence group matching logic.